### PR TITLE
Fixes CODE_OF_CONDUCT link's 404 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Once an issue is assigned to an individual (and one individual only at a time) w
 
 ## ✨ Contributing
 
-By contributing to this repository, you adhere to the rules in our [Code of Conduct](./.github/CODE_OF_CONDUCT.md). Here are a few general instructions for people willing to develop onto the codebase.
+By contributing to this repository, you adhere to the rules in our [Code of Conduct](./CODE_OF_CONDUCT.md). Here are a few general instructions for people willing to develop onto the codebase.
 
 ### • Create issues to discuss your ideas with the maintainers
 


### PR DESCRIPTION
### Related Issue
- Issue number goes here: #16 

 
### Screenshots
Now after this change the error has gone

![Screenshot 2023-10-01 095658](https://github.com/gdsc-aec-india/gdsc-aec-web/assets/74102404/4ca32209-aa49-40da-9fea-15f4d75a7134)
